### PR TITLE
fix: remove npm cache from CI (no lock file) and use npm install

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,9 +15,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20.9.0'
-          cache: 'npm'
 
-      - run: npm ci
+      - run: npm install
 
       - run: npm run generate
         env:


### PR DESCRIPTION
setup-node cache: npm requires package-lock.json which is not committed. npm ci also requires a lock file — replaced with npm install.


Claude-Session: https://claude.ai/code/session_01XmTPizunwMEoBy8McEzEbY