### PR TITLE
Diagnostic: bump footer copyright year to 2026

### DIFF
--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -84,6 +84,6 @@
     "visitSite": "Visit site"
   },
   "footer": {
-    "copyright": "© Copyright 2024 - All rights reserved"
+    "copyright": "© Copyright 2026 - All rights reserved"
   }
 }

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -84,6 +84,6 @@
     "visitSite": "Visitar sitio"
   },
   "footer": {
-    "copyright": "© Copyright 2024 - Todos los derechos reservados"
+    "copyright": "© Copyright 2026 - Todos los derechos reservados"
   }
 }

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -84,6 +84,6 @@
     "visitSite": "Visiter le site"
   },
   "footer": {
-    "copyright": "© Copyright 2024 - Tous droits réservés"
+    "copyright": "© Copyright 2026 - Tous droits réservés"
   }
 }


### PR DESCRIPTION
## Summary
- Bump the footer copyright year from 2024 to 2026 in the 3 locale files (`i18n/locales/es.json`, `en.json`, `fr.json`).

## Why
Diagnostic change to confirm whether new deploys are actually reaching `https://luisventurae.github.io/`. The previous PR (#8) fixed invisible footer social icons and was merged/deployed, but the user still doesn't see the fix live even after hard refresh / incognito across browsers. This visible, trivial change lets us check whether *any* new deploy shows up (cache/propagation issue) or whether something specific to the SVG icon build isn't making it live.

## Test plan
- [ ] Merge and let the `Deploy` GitHub Action run.
- [ ] Confirm the footer on the live site shows "© Copyright 2026" after the workflow completes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Cic4aKRnKUTpPmNfbythsX)_